### PR TITLE
[Docs] Specify onnx opset version for export

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ model = models.get(Models.YOLO_NAS_S, pretrained_weights="coco")
 
 model.eval()
 model.prep_model_for_conversion(input_size=[1, 3, 640, 640])
-model.export("yolo_nas_s.onnx", postprocessing=None, preprocessing=None)
+model.export("yolo_nas_s.onnx", postprocessing=None, preprocessing=None,
+             onnx_export_kwargs={"opset_version":11})
 ```
 
 ## Custom Model


### PR DESCRIPTION
Minor docs update to specify onnx opset version on export. Thank you for your work.

## Issue
 
Ran into an issue while using the exported model in OpenCV
```bash
[ERROR:0@0.101] global ./modules/dnn/src/onnx/onnx_importer.cpp (1018) handleNode DNN/ONNX: ERROR during processing node with 2 inputs and 1 outputs: [ReduceSum]:(onnx_node!/model/heads/ReduceSum) from domain='ai.onnx'
terminate called after throwing an instance of 'cv::Exception'
  what():  OpenCV(4.6.0) ./modules/dnn/src/onnx/onnx_importer.cpp:1040: error: (-2:Unspecified error) in function 'handleNode'
> Node [ReduceSum@ai.onnx]:(onnx_node!/model/heads/ReduceSum) parse error: OpenCV(4.6.0) ./modules/dnn/src/onnx/onnx_importer.cpp:1188: error: (-213:The function/feature is not implemented) Unsupported ReduceSum operation of opset 13, please try to re-export the onnx model with opset 11. in function 'parseReduce'
```

## Why

- The opset currently is default version in `super_gradients`.
- My older export with another method resulted in opset 13, which is not compatible with OpenCV 4.6.0

## Change

- The arg in export function in readme will specify the required version.